### PR TITLE
Queue uploads and skip already-processed images

### DIFF
--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -26,6 +26,7 @@
     input[type="range"]{height:34px}
     .grid{display:grid; grid-template-columns:1fr; gap:16px}
     @media(min-width:1024px){ .grid{grid-template-columns:380px 1fr} }
+    .grid.hide-gallery{grid-template-columns:1fr !important}
 
     /* Albums (originals + crops) */
     .albums{padding:12px}
@@ -66,53 +67,66 @@
     width: 16px; height: 16px; border-radius: 4px;
     background: #1a1d25; margin-right: 6px; cursor: grab;
   }
-  .relative-container {
-    position: relative; /* so floating controls can anchor */
-  }
+    .relative-container {
+      position: relative; /* so floating controls can anchor */
+    }
+
+    /* Collapsible panels */
+    details.card{padding:8px 10px;}
+    details.card>summary{cursor:pointer; user-select:none;}
 
   </style>
 </head>
 <body>
-  <header>
-    <div class="wrap bar">
-      <!-- Upload -->
-      <form id="uploadForm" class="card" style="padding:8px 10px; display:flex; gap:10px; align-items:center;">
-        <input type="file" name="file" accept="image/*,.heic,.HEIC" />
-        <button class="btn" type="submit">Upload</button>
-      </form>
+    <header>
+      <div class="wrap bar">
+        <!-- Upload Queue -->
+        <details class="card" id="uploadSection">
+          <summary>Upload</summary>
+          <form id="uploadForm" style="margin-top:8px; display:flex; gap:10px; align-items:center;">
+            <input type="file" name="file" accept="image/*,.heic,.HEIC" multiple />
+            <button class="btn" type="submit">Add to Queue</button>
+          </form>
+          <div id="queueStatus" style="margin-top:4px; color:var(--sub); font-size:12px;"></div>
+        </details>
 
-      <!-- Settings -->
-      <div class="card" style="padding:8px 10px; display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
-        <label>Model
-          <select id="model_type">
-            <option value="vit_b">ViT-B</option>
-            <option value="vit_l">ViT-L</option>
-            <option value="vit_h">ViT-H</option>
-          </select>
-        </label>
-        <label>Points
-          <input type="range" id="points_slider" min="8" max="128" value="32" />
-          <input type="number" id="points_input" min="8" max="128" value="32" style="width:80px" />
-        </label>
-        <label>IoU
-          <input type="range" id="iou_slider" min="0.5" max="0.99" step="0.01" value="0.88" />
-          <input type="number" id="iou_input" min="0.5" max="0.99" step="0.01" value="0.88" style="width:80px" />
-        </label>
-        <label>Stability
-          <input type="range" id="stab_slider" min="0.5" max="0.99" step="0.01" value="0.95" />
-          <input type="number" id="stab_input" min="0.5" max="0.99" step="0.01" value="0.95" style="width:80px" />
-        </label>
-        <label>Crop layers
-          <input type="number" id="crop_layers" min="0" max="3" value="1" style="width:80px" />
-        </label>
-        <button class="btn" id="saveBtn" type="button">Save settings</button>
+        <!-- SAM Controls -->
+        <details class="card" id="samSection">
+          <summary>SAM Controls</summary>
+          <div style="margin-top:8px; display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
+            <label>Model
+              <select id="model_type">
+                <option value="vit_b">ViT-B</option>
+                <option value="vit_l">ViT-L</option>
+                <option value="vit_h">ViT-H</option>
+              </select>
+            </label>
+            <label>Points
+              <input type="range" id="points_slider" min="8" max="128" value="32" />
+              <input type="number" id="points_input" min="8" max="128" value="32" style="width:80px" />
+            </label>
+            <label>IoU
+              <input type="range" id="iou_slider" min="0.5" max="0.99" step="0.01" value="0.88" />
+              <input type="number" id="iou_input" min="0.5" max="0.99" step="0.01" value="0.88" style="width:80px" />
+            </label>
+            <label>Stability
+              <input type="range" id="stab_slider" min="0.5" max="0.99" step="0.01" value="0.95" />
+              <input type="number" id="stab_input" min="0.5" max="0.99" step="0.01" value="0.95" style="width:80px" />
+            </label>
+            <label>Crop layers
+              <input type="number" id="crop_layers" min="0" max="3" value="1" style="width:80px" />
+            </label>
+            <button class="btn" id="saveBtn" type="button">Save settings</button>
+          </div>
+        </details>
+
+        <button class="btn ghost" id="toggleGallery">Hide Originals & Clippings</button>
       </div>
-    </div>
-  </header>
+    </header>
 
-  <main class="wrap grid">
+  <main id="mainGrid" class="wrap grid">
     <!-- LEFT: Albums / Originals -->
-    <section class="card albums">
+    <section class="card albums" id="albumsSection">
       <h3 style="margin:4px 0 12px 2px; color:var(--sub);">Originals & Clippings</h3>
       <div id="albums"></div>
     </section>
@@ -192,15 +206,65 @@
       alert("Settings saved");
     });
 
-    // ---------- upload (fetch; prevent JSON navigation) ----------
-    document.getElementById("uploadForm").addEventListener("submit", async (e)=>{
+    // ---------- upload queue ----------
+    const uploadQueue = [];
+    let uploading = false;
+    const queueStatus = document.getElementById("queueStatus");
+
+    function updateQueueStatus(){
+      if(uploading){
+        queueStatus.textContent = `Uploading... ${uploadQueue.length} left`;
+      } else if(uploadQueue.length>0){
+        queueStatus.textContent = `${uploadQueue.length} queued`;
+      } else {
+        queueStatus.textContent = "";
+      }
+    }
+
+    async function processQueue(){
+      if(uploading) return;
+      uploading = true;
+      while(uploadQueue.length>0){
+        updateQueueStatus();
+        const file = uploadQueue.shift();
+        const fd = new FormData();
+        fd.append("file", file, file.name);
+        const res = await fetch("/upload",{method:"POST", body:fd, headers:{Accept:"application/json"}});
+        if(!res.ok){ console.error("Upload failed for", file.name); }
+        await refreshAlbums();
+      }
+      uploading = false;
+      updateQueueStatus();
+    }
+
+    document.getElementById("uploadForm").addEventListener("submit", (e)=>{
       e.preventDefault();
-      const fd = new FormData(e.target);
-      const res = await fetch("/upload",{method:"POST", body:fd, headers:{Accept:"application/json"}});
-      if(!res.ok){ alert("Upload failed"); return; }
-      await refreshAlbums();
-      e.target.reset();
+      const input = e.target.querySelector('input[name="file"]');
+      const files = input.files;
+      for(const f of files) uploadQueue.push(f);
+      input.value = "";
+      updateQueueStatus();
+      processQueue();
     });
+
+    // ---------- toggle gallery ----------
+    const toggleBtn = document.getElementById("toggleGallery");
+    const albumsSection = document.getElementById("albumsSection");
+    const mainGrid = document.getElementById("mainGrid");
+    toggleBtn.addEventListener("click", () => {
+      const hidden = albumsSection.style.display === "none";
+      if (hidden) {
+        albumsSection.style.display = "block";
+        mainGrid.classList.remove("hide-gallery");
+        toggleBtn.textContent = "Hide Originals & Clippings";
+      } else {
+        albumsSection.style.display = "none";
+        mainGrid.classList.add("hide-gallery");
+        toggleBtn.textContent = "Show Originals & Clippings";
+      }
+    });
+    // start with gallery hidden so canvas has full width on load
+    toggleBtn.click();
 
     // ---------- albums (originals + crops) ----------
     const openState = {};  // { "file.png": true/false }

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -14,8 +14,28 @@ RESIZED_DIR = os.path.join(SHARED_DIR, "resized")
 MASKS_DIR = os.path.join(SHARED_DIR, "output", "masks")
 CONFIG_FILE = os.path.join(SHARED_DIR, "config", "settings.json")
 MODEL_PATH = os.path.join(SHARED_DIR, "models", "vit_l.pth")
+PROCESSED_FILE = os.path.join(SHARED_DIR, "output", "processed.json")
 
 os.makedirs(MASKS_DIR, exist_ok=True)
+
+
+def load_processed_list():
+    """Read list of already-processed filenames from disk."""
+    if os.path.exists(PROCESSED_FILE):
+        try:
+            with open(PROCESSED_FILE, "r") as f:
+                return set(json.load(f))
+        except Exception:
+            return set()
+    return set()
+
+
+def save_processed_list(processed_set):
+    """Persist processed filenames to disk atomically."""
+    tmp = PROCESSED_FILE + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(sorted(processed_set), f)
+    os.replace(tmp, PROCESSED_FILE)
 
 # -------------------------
 # Load SAM model
@@ -62,33 +82,50 @@ def save_masks(masks, image, base_name):
     """Save masks as PNGs to MASKS_DIR"""
     for idx, mask_dict in enumerate(masks):
         mask = mask_dict["segmentation"].astype(np.uint8) * 255
-        mask_file = os.path.join(MASKS_DIR, f"{os.path.splitext(base_name)[0]}_mask{idx}.png")
+        mask_file = os.path.join(
+            MASKS_DIR, f"{os.path.splitext(base_name)[0]}_mask{idx}.png"
+        )
         # Resize to original image size if needed
         if mask.shape != image.shape[:2]:
-            mask = cv2.resize(mask, (image.shape[1], image.shape[0]), interpolation=cv2.INTER_NEAREST)
+            mask = cv2.resize(
+                mask, (image.shape[1], image.shape[0]), interpolation=cv2.INTER_NEAREST
+            )
         cv2.imwrite(mask_file, mask)
+
+
+def already_processed(filename, processed_set):
+    """Return True if masks or a processed marker exist for the given image."""
+    base = os.path.splitext(filename)[0]
+    prefix = f"{base}_mask"
+    if any(fname.startswith(prefix) for fname in os.listdir(MASKS_DIR)):
+        return True
+    return filename in processed_set
 
 # -------------------------
 # Watcher loop
 # -------------------------
-processed = set()
+processed = load_processed_list()
 
 while True:
     settings = load_settings()
     for f in os.listdir(RESIZED_DIR):
-        if f.endswith((".png", ".jpg", ".jpeg")) and f not in processed:
-            file_path = os.path.join(RESIZED_DIR, f)
-            start = time.process_time()
-            print(f"[Worker] Processing {f} ...")
-            try:
-                masks, img = generate_masks(file_path, settings)
-                save_masks(masks, img, f)
-                processed.add(f)
-                # Clean up memory
-                gc.collect()
-                end = time.process_time()
-                total = end - start
-                print(f'elapsed time: {total:.6f} seconds')
-            except Exception as e:
-                print(f"[Worker] Error processing {f}: {e}")
+        if not f.endswith((".png", ".jpg", ".jpeg")):
+            continue
+        if already_processed(f, processed):
+            continue
+        file_path = os.path.join(RESIZED_DIR, f)
+        start = time.process_time()
+        print(f"[Worker] Processing {f} ...")
+        try:
+            masks, img = generate_masks(file_path, settings)
+            save_masks(masks, img, f)
+            processed.add(f)
+            save_processed_list(processed)
+            # Clean up memory
+            gc.collect()
+            end = time.process_time()
+            total = end - start
+            print(f'elapsed time: {total:.6f} seconds')
+        except Exception as e:
+            print(f"[Worker] Error processing {f}: {e}")
     time.sleep(2)


### PR DESCRIPTION
## Summary
- Persist a list of processed images so Server2 skips work on already-masked files
- Start the main page with the "Originals & Clippings" gallery hidden to free canvas space

## Testing
- `python -m py_compile server1/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8fd09b558832e9af969d2810a2f5d