### PR TITLE
Add rembg refinement for uniform largest crop

### DIFF
--- a/server2/requirements.txt
+++ b/server2/requirements.txt
@@ -3,5 +3,7 @@ numpy
 torch
 torchvision
 git+https://github.com/facebookresearch/segment-anything.git
+rembg
+onnxruntime
 
 #segment-anything  # if pip-installable, else clone from github in Dockerfile


### PR DESCRIPTION
## Summary
- move rembg usage to server2 worker with CUDA support
- drop rembg dependency from server1
- include rembg and onnxruntime in Server2 requirements

## Testing
- `python -m py_compile server1/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9c53397b0832e9ce8bb4510cbfe37