### PR TITLE
fix rembg model name

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -14,7 +14,9 @@ try:
 except Exception:  # pragma: no cover - torch may not be installed
     _REMBG_PROVIDERS = ["CPUExecutionProvider"]
 
-_REMBG_SESSION = new_session("dis", providers=_REMBG_PROVIDERS)
+# Rembg does not ship a model named "dis". Use the default "u2net" model
+# to avoid runtime errors when initializing the background removal session.
+_REMBG_SESSION = new_session("u2net", providers=_REMBG_PROVIDERS)
 
 # -------------------------
 # Config / directories


### PR DESCRIPTION
## Summary
- replace invalid rembg model name 'dis' with supported 'u2net'

## Testing
- `python -m py_compile server2/worker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa057c37d4832ea14f6bf831637f67