### PR TITLE
Add BiRefNet DIS post-processing and mask inversion

### DIFF
--- a/server2/requirements.txt
+++ b/server2/requirements.txt
@@ -5,5 +5,6 @@ torchvision
 git+https://github.com/facebookresearch/segment-anything.git
 rembg
 onnxruntime
+birefnet
 
 #segment-anything  # if pip-installable, else clone from github in Dockerfile


### PR DESCRIPTION
## Summary
- integrate optional BiRefNet DIS model to refine masks for mono-color images
- invert masks that cover >90% of the image to catch small foreground objects
- require BiRefNet package in worker service

## Testing
- `python -m py_compile server2/worker.py`
- `pip install birefnet` *(fails: Could not find a version that satisfies the requirement birefnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aa221bb7c8832eab3414b96ca8d695