### PR TITLE
Improve thumbnail display on Server1

### DIFF
--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -33,7 +33,7 @@
     .album{background:var(--panel); border:1px solid var(--muted); border-radius:12px; overflow:hidden; margin-bottom:12px}
     .albumHead{display:flex; gap:12px; align-items:center; padding:10px 12px; cursor:pointer}
     .albumHead:hover{background:#161a27}
-    .thumb{width:64px; height:64px; object-fit:contain; background:#0e1017; border:1px solid var(--muted); border-radius:10px}
+    .thumb{width:96px; height:96px; object-fit:contain; object-position:center; background:#0e1017; border:1px solid var(--muted); border-radius:10px}
     .meta{display:flex; flex-direction:column}
     .meta b{font-size:13px}
     .meta span{color:var(--sub); font-size:12px}


### PR DESCRIPTION
## Summary
- Ensure preview thumbnails display the full image by centering scaling
- Increase thumbnail size to make previews easier to see

## Testing
- `python -m py_compile server1/app.py server2/worker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa299aace0832e85c10abdb816d5d2