### PR TITLE
Crop paper sheets before processing and handle off-center masks

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -51,6 +51,54 @@ def normalize_to_png_and_save(pil_img: Image.Image, out_path_png: str, longest_s
         img.thumbnail((longest_side, longest_side), Image.LANCZOS)
     img.save(out_path_png, "PNG")
 
+
+def detect_and_crop_sheet(pil_img: Image.Image) -> Image.Image:
+    """
+    Attempt to locate a sheet of paper in the image and return a cropped, top-down view.
+    If detection fails, returns the original image.
+    """
+    try:
+        img = np.array(pil_img)
+        bgr = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+        gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (5, 5), 0)
+        edges = cv2.Canny(blur, 50, 150)
+
+        contours, _ = cv2.findContours(edges, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        contours = sorted(contours, key=cv2.contourArea, reverse=True)
+        for cnt in contours[:5]:
+            peri = cv2.arcLength(cnt, True)
+            approx = cv2.approxPolyDP(cnt, 0.02 * peri, True)
+            if len(approx) == 4:
+                pts = approx.reshape(4, 2).astype("float32")
+
+                # order points: tl, tr, br, bl
+                s = pts.sum(axis=1)
+                diff = np.diff(pts, axis=1)
+                rect = np.zeros((4, 2), dtype="float32")
+                rect[0] = pts[np.argmin(s)]
+                rect[2] = pts[np.argmax(s)]
+                rect[1] = pts[np.argmin(diff)]
+                rect[3] = pts[np.argmax(diff)]
+
+                widthA = np.linalg.norm(rect[2] - rect[3])
+                widthB = np.linalg.norm(rect[1] - rect[0])
+                maxWidth = int(max(widthA, widthB))
+                heightA = np.linalg.norm(rect[1] - rect[2])
+                heightB = np.linalg.norm(rect[0] - rect[3])
+                maxHeight = int(max(heightA, heightB))
+
+                dst = np.array(
+                    [[0, 0], [maxWidth - 1, 0], [maxWidth - 1, maxHeight - 1], [0, maxHeight - 1]],
+                    dtype="float32",
+                )
+                M = cv2.getPerspectiveTransform(rect, dst)
+                warped = cv2.warpPerspective(bgr, M, (maxWidth, maxHeight))
+                return Image.fromarray(cv2.cvtColor(warped, cv2.COLOR_BGR2RGB))
+    except Exception:
+        pass
+    return pil_img
+
 def load_crops_index() -> Dict[str, List[str]]:
     if os.path.exists(CROPS_INDEX):
         try:
@@ -143,6 +191,9 @@ def upload():
         pil_img = Image.open(file.stream)
     except Exception as e:
         return f"Failed to open image: {e}", 400
+
+    # Step 1: detect sheet of paper and crop before further processing
+    pil_img = detect_and_crop_sheet(pil_img)
 
     # Normalize original to PNG in /input
     input_png = os.path.join(INPUT_DIR, f"{stem}.png")

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -283,9 +283,18 @@ while True:
                             largest["segmentation"] = _refine_mask_with_rembg(img).astype(bool)
                     h, w = img.shape[:2]
                     total_pixels = h * w
-                    for m in masks:
-                        if np.count_nonzero(m["segmentation"]) > 0.9 * total_pixels:
-                            m["segmentation"] = np.logical_not(m["segmentation"])
+                    center_y, center_x = h // 2, w // 2
+                    for m in list(masks):
+                        seg = m["segmentation"]
+                        seg_resized = seg
+                        if seg.shape != (h, w):
+                            seg_resized = cv2.resize(
+                                seg.astype(np.uint8), (w, h), interpolation=cv2.INTER_NEAREST
+                            ).astype(bool)
+                        if np.count_nonzero(seg_resized) > 0.9 * total_pixels and not seg_resized[center_y, center_x]:
+                            inverse = m.copy()
+                            inverse["segmentation"] = np.logical_not(seg)
+                            masks.append(inverse)
                 save_masks(masks, img, base)
             processed.add(base)
             save_processed_set(processed)


### PR DESCRIPTION
## Summary
- Detect rectangular paper in uploads and crop it before resizing and further processing
- Append inverse mask when a large mask misses the canvas center

## Testing
- `python -m py_compile server1/app.py server2/worker.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa645dbf04832eaa4e62c06f0a0fd5