### PR TITLE
Generate and serve thumbnails for originals and clippings

### DIFF
--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -294,7 +294,7 @@
         head.className="albumHead"; head.dataset.original = a.original;
         const isOpen = !!openState[a.original]; const arrow = isOpen ? "▲" : "▼";
         head.innerHTML = `
-          <img class="thumb" src="${a.original_url}" alt="">
+          <img class="thumb" src="${a.original_thumb_url}" alt="">
           <div class="meta">
             <b>${a.original}</b>
             <span>${a.crops.length} clipping${a.crops.length===1?"":"s"}</span>
@@ -312,7 +312,7 @@
         }else{
           a.crops.forEach(c=>{
             const chip=document.createElement("div"); chip.className="chip";
-            const img=document.createElement("img"); img.src=c.url; img.alt=c.file; img.title="Add to canvas";
+            const img=document.createElement("img"); img.src=c.thumb_url; img.alt=c.file; img.title="Add to canvas";
             img.onclick=()=> addToCanvas(c.url);
             chip.appendChild(img); chips.appendChild(chip);
           });


### PR DESCRIPTION
## Summary
- create thumbnail directories for original images and clippings
- generate thumbnails and expose routes to serve them
- use thumbnail URLs in the album view for faster page loads

## Testing
- `python -m py_compile server1/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac53095684832e8834643668aba1ee