### PR TITLE
Reload processed list each loop

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -253,10 +253,10 @@ def save_masks(masks, image, base_name):
 # -------------------------
 # Watcher loop
 # -------------------------
-processed = load_processed_set()
 
 while True:
     settings = load_settings()
+    processed = load_processed_set()
     files = [f for f in os.listdir(RESIZED_DIR) if f.endswith((".png", ".jpg", ".jpeg"))]
     if not files:
         print("[Worker] No pages found")


### PR DESCRIPTION
## Summary
- Ensure server2 worker reloads processed file list on every iteration so newly uploaded files are picked up even after clearing state.

## Testing
- `python -m py_compile server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6d8390f0832ea0a0494ab0056192