### PR TITLE
Ensure shared directories exist for uploads

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -48,6 +48,7 @@ os.environ.setdefault("U2NET_HOME", os.path.join(SHARED_DIR, "models"))
 _REMBG_SESSION = new_session("birefnet-dis", providers=_REMBG_PROVIDERS)
 
 
+os.makedirs(RESIZED_DIR, exist_ok=True)
 os.makedirs(MASKS_DIR, exist_ok=True)
 os.makedirs(SMALLS_DIR, exist_ok=True)
 os.makedirs(CROPS_DIR, exist_ok=True)

--- a/shared/input/.gitkeep
+++ b/shared/input/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/shared/output/masks/.gitkeep
+++ b/shared/output/masks/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/shared/output/pages/.gitkeep
+++ b/shared/output/pages/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/shared/output/smalls/.gitkeep
+++ b/shared/output/smalls/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/shared/output/thumbs/clippings/.gitkeep
+++ b/shared/output/thumbs/clippings/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/shared/output/thumbs/originals/.gitkeep
+++ b/shared/output/thumbs/originals/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/shared/resized/.gitkeep
+++ b/shared/resized/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists


### PR DESCRIPTION
## Summary
- Add placeholder files to shared directories so input, resized, and output paths are always present
- Initialize the `resized` directory in worker2 to guarantee new uploads are detected

## Testing
- `python -m py_compile server2/worker.py server1/app.py`
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68ac70011904832ea8af9b0fe57ebdf6