### PR TITLE
Fix mask filtering to avoid numpy comparison error

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -315,7 +315,8 @@ while True:
                         h, w = page_img.shape[:2]
                         total_pixels = h * w
                         center_y, center_x = h // 2, w // 2
-                        for m in list(masks):
+                        filtered_masks = []
+                        for m in masks:
                             seg = np.squeeze(m["segmentation"]).astype(bool)
                             seg_resized = seg
                             if seg.shape != (h, w):
@@ -325,11 +326,13 @@ while True:
                             area = np.count_nonzero(seg_resized)
                             if area > 0.9 * total_pixels:
                                 if np.any(seg_resized[center_y, center_x]):
-                                    masks.remove(m)
                                     continue
                                 inverse = m.copy()
                                 inverse["segmentation"] = np.logical_not(seg)
-                                masks.append(inverse)
+                                filtered_masks.append(inverse)
+                            else:
+                                filtered_masks.append(m)
+                        masks = filtered_masks
                     save_masks(masks, page_img, page_base)
             processed.add(base)
             save_processed_set(processed)


### PR DESCRIPTION
## Summary
- prevent ambiguous truth value errors when removing large masks
- ensure segmentation masks are filtered without repeated processing

## Testing
- `python -m py_compile server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68acaddc721c832e8670cb263bafe20c