### PR TITLE
Clear processed removes all inputs/outputs and thumbnails

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -366,8 +366,16 @@ def list_crops():
 
 @app.route("/clear_all", methods=["POST"])
 def clear_all():
-    """Remove all processed images and trackers."""
-    dirs = [INPUT_DIR, RESIZED_DIR, MASKS_DIR, CROPS_DIR, SMALLS_DIR]
+    """Remove all inputs, outputs, thumbnails, and trackers."""
+    dirs = [
+        INPUT_DIR,
+        RESIZED_DIR,
+        MASKS_DIR,
+        CROPS_DIR,
+        SMALLS_DIR,
+        THUMBS_ORIG_DIR,
+        THUMBS_CLIP_DIR,
+    ]
     for d in dirs:
         for name in os.listdir(d):
             path = os.path.join(d, name)


### PR DESCRIPTION
## Summary
- Ensure `/clear_all` wipes inputs, outputs, masks, crops, smalls, thumbnails, and the processed tracker

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acb90da000832e901001ebe2c244f1