### PR TITLE
Emit mask PNGs for page detection

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -19,7 +19,7 @@ import pillow_heif  # enables HEIC/HEIF decode in Pillow
 SHARED_DIR   = "/mnt/shared"
 INPUT_DIR    = os.path.join(SHARED_DIR, "input")              # originals (PNG-normalized)
 RESIZED_DIR  = os.path.join(SHARED_DIR, "resized")            # ≤1024 for SAM
-MASKS_DIR    = os.path.join(SHARED_DIR, "output", "masks")    # from Server2
+MASKS_DIR    = os.path.join(SHARED_DIR, "output", "masks")    # mask PNGs from Server2 worker
 CROPS_DIR    = os.path.join(SHARED_DIR, "output", "crops")    # RGBA crops
 SMALLS_DIR   = os.path.join(SHARED_DIR, "output", "smalls")
 THUMBS_ORIG_DIR = os.path.join(SHARED_DIR, "output", "thumbs", "originals")


### PR DESCRIPTION
## Summary
- output detected page masks from worker to `/mnt/shared/output/masks`
- document mask directory in server1
- use original-resolution mask when no pages are detected so full images still flow through the pipeline

## Testing
- `python -m pytest` *(no tests found)*
- `python -m py_compile server2/worker.py server1/app.py`
- `python - <<'PY'\nimport cv2\nprint(cv2.__version__)\nPY` *(failed: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68acea1c2be4832e805ce282158cd287