### PR TITLE
fix: load YOLO models from shared volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,4 +27,3 @@ services:
             - capabilities: [gpu]
     volumes:
       - ./shared:/mnt/shared
-      - ./shared/models:/models

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -7,7 +7,7 @@ from ultralytics import YOLO
 SHARED_DIR = "/mnt/shared"
 RESIZED_DIR = os.path.join(SHARED_DIR, "resized")
 OUTPUT_DIR = os.path.join(SHARED_DIR, "output", "boxes")
-MODEL_DIR = "/models"
+MODEL_DIR = os.path.join(SHARED_DIR, "models")
 
 # Dynamically load all YOLO models found in MODEL_DIR
 MODELS: dict[str, YOLO] = {}


### PR DESCRIPTION
## Summary
- look for YOLO model weights under `/mnt/shared/models`
- simplify server2 docker-compose volume mounting

## Testing
- `python -m py_compile server2/worker.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68afb55e16ec832e9a2375fe1153f108