### PR TITLE
feat: add rf-detr, rt-detr, and d-fine options

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -116,7 +116,7 @@ def save_crops_index(index: Dict[str, List[str]]) -> None:
 
 def ensure_settings_defaults() -> dict:
     defaults = {
-        "model_type": "vit_b",         # allow vit_b / vit_l / vit_h
+        "model_type": "vit_b",         # allow vit_b / vit_l / vit_h / rf-detr / rt-detr / d-fine
         "points_per_side": 32,
         "pred_iou_thresh": 0.88,
         "stability_score_thresh": 0.95,

--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -99,6 +99,9 @@
                 <option value="vit_b">ViT-B</option>
                 <option value="vit_l">ViT-L</option>
                 <option value="vit_h">ViT-H</option>
+                <option value="rf-detr">RF-DETR</option>
+                <option value="rt-detr">RT-DETR</option>
+                <option value="d-fine">D-FINE</option>
               </select>
             </label>
             <label>Points


### PR DESCRIPTION
## Summary
- add rf-detr, rt-detr, and d-fine to the model dropdown
- clarify settings defaults comment with new model options

## Testing
- `python -m py_compile server1/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0b5243cd4832e91cee516d7c41673