### PR TITLE
Support DETR and D-FINE models alongside YOLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Artwork Object Detection Server
 
-This fork removes SAM and Rembg processing and instead uses YOLO models trained on artwork to detect objects. Each model produces a single output image with bounding boxes and its name overlaid on the image.
+This fork removes SAM and Rembg processing and instead uses detection models trained on artwork (YOLO, DETR, D-FINE) to detect objects. Each model produces a single output image with bounding boxes and its name overlaid on the image.
 
 ## Model Weights
 


### PR DESCRIPTION
## Summary
- Extend worker to load multiple detector architectures (YOLO, DETR, D-FINE) and run each on incoming images
- Document support for DETR and D-FINE models in the README

## Testing
- `python -m py_compile server2/worker.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0b6e89408832eb0bce878277db481