### PR TITLE
Auto-load new detection weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Artwork Object Detection Server
 
-This fork removes SAM and Rembg processing and instead uses YOLO models trained on artwork to detect objects. Each model produces a single output image with bounding boxes and its name overlaid on the image.
+This fork removes SAM and Rembg processing and instead uses detection models trained on artwork (YOLO, DETR, D-FINE) to detect objects. Each model produces a single output image with bounding boxes and its name overlaid on the image.
 
 ## Model Weights
 
-
+Place any detection weights (`.pt`/`.pth`) in `shared/models` (mounted at
+`/models` in the containers). Files with `detr` or `dfine` in their names are
+treated as DETR or D‑FINE models; everything else loads through the YOLO
+interface. The worker monitors this directory and loads new weights on the fly
+so you can drop in additional models without restarting the container.
 
 ```bash
 # Server 1

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -1,6 +1,9 @@
 import os
 import time
 import cv2
+import torch
+import torchvision.transforms as T
+from dataclasses import dataclass
 from ultralytics import YOLO
 
 # Directories
@@ -16,22 +19,112 @@ if not os.path.isdir(MODEL_DIR):
     MODEL_DIR = os.path.join(SHARED_DIR, "models")
 
 
-# Dynamically load all detection models found in MODEL_DI
-MODELS: dict[str, YOLO] = {}
-if os.path.isdir(MODEL_DIR):
-    for fname in os.listdir(MODEL_DIR):
-        if fname.lower().endswith((".pt", ".pth")):
-            path = os.path.join(MODEL_DIR, fname)
-            name = os.path.splitext(fname)[0]
-            try:
-                MODELS[name] = YOLO(path)
-            except Exception as e:
-                print(f"[Worker] Failed to load {fname}: {e}")
-    if not MODELS:
-        print(f"[Worker] No YOLO models found in {MODEL_DIR}")
+@dataclass
+class DetectionModel:
+    name: str
+    model: object
+    kind: str  # 'yolo', 'detr', 'dfine'
 
-else:
-    print(f"[Worker] Model directory not found: {MODEL_DIR}")
+    def predict(self, image):
+        """Return list of (x1, y1, x2, y2, label)"""
+        if self.kind in {"yolo", "dfine"}:  # D-FINE uses YOLO-style interface
+            results = self.model(image)[0]
+            out = []
+            for box in results.boxes:
+                x1, y1, x2, y2 = map(int, box.xyxy[0])
+                cls_id = int(box.cls[0]) if box.cls is not None else -1
+                label = results.names.get(cls_id, str(cls_id))
+                out.append((x1, y1, x2, y2, label))
+            return out
+        if self.kind == "detr":
+            transform = T.Compose([T.ToTensor()])
+            tensor = transform(image).unsqueeze(0)
+            with torch.no_grad():
+                outputs = self.model(tensor)
+            probas = outputs["pred_logits"].softmax(-1)[0, :, :-1]
+            keep = probas.max(-1).values > 0.7
+            boxes = outputs["pred_boxes"][0, keep].cpu().numpy()
+            class_ids = probas[keep].argmax(-1).cpu().numpy()
+            h, w = image.shape[:2]
+            out = []
+            for (cx, cy, bw, bh), cls_id in zip(boxes, class_ids):
+                x1 = int((cx - 0.5 * bw) * w)
+                y1 = int((cy - 0.5 * bh) * h)
+                x2 = int((cx + 0.5 * bw) * w)
+                y2 = int((cy + 0.5 * bh) * h)
+                out.append((x1, y1, x2, y2, str(cls_id)))
+            return out
+        return []
+
+
+def load_models(model_dir: str, models: dict[str, DetectionModel] | None = None) -> dict[str, DetectionModel]:
+    """Populate ``models`` with any weights found in ``model_dir``.
+
+    Subsequent calls will only attempt to load weights that are not already
+    present in ``models`` so that new files dropped into the directory are
+    picked up automatically without restarting the worker.
+    """
+
+    if models is None:
+        models = {}
+
+    if not os.path.isdir(model_dir):
+        print(f"[Worker] Model directory not found: {model_dir}")
+        return models
+
+    for fname in os.listdir(model_dir):
+        if not fname.lower().endswith((".pt", ".pth")):
+            continue
+
+        name = os.path.splitext(fname)[0]
+        if name in models:
+            continue
+
+        path = os.path.join(model_dir, fname)
+        try:
+            yolo = YOLO(path)
+            models[name] = DetectionModel(name, yolo, "yolo")
+            print(f"[Worker] Loaded YOLO model: {fname}")
+            continue
+        except Exception as e:
+            print(f"[Worker] Failed to load {fname} with YOLO: {e}")
+
+        lower = name.lower()
+        if "detr" in lower:
+            try:
+                detr = torch.hub.load(
+                    "facebookresearch/detr", "detr_resnet50", pretrained=False
+                )
+                state = torch.load(path, map_location="cpu")
+                state = state.get("model", state)
+                detr.load_state_dict(state)
+                detr.eval()
+                models[name] = DetectionModel(name, detr, "detr")
+                print(f"[Worker] Loaded DETR model: {fname}")
+                continue
+            except Exception as e2:
+                print(f"[Worker] Failed to load {fname} as DETR: {e2}")
+        if "dfine" in lower or "d-fine" in lower:
+            try:
+                dfine = torch.hub.load(
+                    "lyuwenyu/D-FINE", "dfine_r18", pretrained=False
+                )
+                state = torch.load(path, map_location="cpu")
+                dfine.load_state_dict(state)
+                dfine.eval()
+                models[name] = DetectionModel(name, dfine, "dfine")
+                print(f"[Worker] Loaded D-FINE model: {fname}")
+                continue
+            except Exception as e2:
+                print(f"[Worker] Failed to load {fname} as D-FINE: {e2}")
+
+    if not models:
+        print(f"[Worker] No detection models found in {model_dir}")
+    return models
+
+
+# Dynamically load all detection models found in MODEL_DIR
+MODELS = load_models(MODEL_DIR)
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -41,6 +134,9 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 processed: dict[str, set[str]] = {}
 
 while True:
+    # Load any newly added model weights before processing images
+    load_models(MODEL_DIR, MODELS)
+
     files = [f for f in os.listdir(RESIZED_DIR) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
     if not files:
         print("[Worker] No images found")
@@ -61,12 +157,9 @@ while True:
             if model_name in done_models:
                 continue
 
-            results = model(image)[0]
+            predictions = model.predict(image)
             annotated = image.copy()
-            for box in results.boxes:
-                x1, y1, x2, y2 = map(int, box.xyxy[0])
-                cls_id = int(box.cls[0]) if box.cls is not None else -1
-                label = results.names.get(cls_id, str(cls_id))
+            for x1, y1, x2, y2, label in predictions:
                 cv2.rectangle(annotated, (x1, y1), (x2, y2), (0, 255, 0), 2)
                 cv2.putText(
                     annotated,


### PR DESCRIPTION
## Summary
- watch the model directory and load new YOLO/DETR/D-FINE weights without restarting
- document that dropping `.pt`/`.pth` files into `shared/models` is picked up automatically

## Testing
- `python -m py_compile server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0b6e89408832eb0bce878277db481