### PR TITLE
Add detection box viewer and support non-YOLO models

### DIFF
--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -300,7 +300,7 @@
           <img class="thumb" src="${a.original_url}" alt="">
           <div class="meta">
             <b>${a.original}</b>
-            <span>${a.crops.length} clipping${a.crops.length===1?"":"s"}</span>
+            <span>${a.crops.length} clipping${a.crops.length===1?"":"s"} · ${a.boxes.length} box${a.boxes.length===1?"":"es"}</span>
           </div>
           <div class="arrow" style="margin-left:auto;color:var(--sub);">${arrow}</div>
         `;
@@ -308,19 +308,39 @@
         const body = document.createElement("div");
         body.className="albumBody"; body.style.display = isOpen ? "block" : "none";
 
-        const chips = document.createElement("div"); chips.className="chips";
+        const cropTitle=document.createElement("div"); cropTitle.textContent="Clippings";
+        body.appendChild(cropTitle);
+
+        const cropChips = document.createElement("div"); cropChips.className="chips";
         if(a.crops.length===0){
           const empty=document.createElement("div"); empty.className="chip"; empty.textContent="No clippings yet.";
-          chips.appendChild(empty);
+          cropChips.appendChild(empty);
         }else{
           a.crops.forEach(c=>{
             const chip=document.createElement("div"); chip.className="chip";
             const img=document.createElement("img"); img.src=c.url; img.alt=c.file; img.title="Add to canvas";
             img.onclick=()=> addToCanvas(c.url);
-            chip.appendChild(img); chips.appendChild(chip);
+            chip.appendChild(img); cropChips.appendChild(chip);
           });
         }
-        body.appendChild(chips);
+        body.appendChild(cropChips);
+
+        const boxTitle=document.createElement("div"); boxTitle.textContent="Boxes"; boxTitle.style.marginTop="8px";
+        body.appendChild(boxTitle);
+
+        const boxChips=document.createElement("div"); boxChips.className="chips";
+        if(a.boxes.length===0){
+          const empty=document.createElement("div"); empty.className="chip"; empty.textContent="No boxes yet.";
+          boxChips.appendChild(empty);
+        }else{
+          a.boxes.forEach(b=>{
+            const chip=document.createElement("div"); chip.className="chip";
+            const img=document.createElement("img"); img.src=b.url; img.alt=b.file; img.title=b.model;
+            img.onclick=()=> addToCanvas(b.url);
+            chip.appendChild(img); boxChips.appendChild(chip);
+          });
+        }
+        body.appendChild(boxChips);
 
         head.addEventListener("click", ()=>{
           const key=head.dataset.original;

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -37,7 +37,10 @@ class DetectionModel:
                 out.append((x1, y1, x2, y2, label))
             return out
         if self.kind == "detr":
-            transform = T.Compose([T.ToTensor()])
+            transform = T.Compose([
+                T.ToTensor(),
+                T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+            ])
             tensor = transform(image).unsqueeze(0)
             with torch.no_grad():
                 outputs = self.model(tensor)
@@ -95,7 +98,8 @@ def load_models(model_dir: str, models: dict[str, DetectionModel] | None = None)
         if "detr" in lower:
             try:
                 detr = torch.hub.load(
-                    "facebookresearch/detr", "detr_resnet50", pretrained=False
+                    "facebookresearch/detr", "detr_resnet50", pretrained=False,
+                    trust_repo=True,
                 )
                 state = torch.load(path, map_location="cpu")
                 state = state.get("model", state)
@@ -109,7 +113,8 @@ def load_models(model_dir: str, models: dict[str, DetectionModel] | None = None)
         if "dfine" in lower or "d-fine" in lower:
             try:
                 dfine = torch.hub.load(
-                    "lyuwenyu/D-FINE", "dfine_r18", pretrained=False
+                    "lyuwenyu/D-FINE", "dfine_r18", pretrained=False,
+                    trust_repo=True,
                 )
 
                 state = torch.load(path, map_location="cpu")


### PR DESCRIPTION
## Summary
- Normalize DETR inputs and load DETR/D-FINE weights with trusted torch hub repos
- Serve detection box images and include them in original image listings
- Display detection box thumbnails in the gallery alongside clippings

## Testing
- `python -m py_compile server1/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e057d704832eb5369daab578bf7a