### PR TITLE
Show YOLO detections on gallery thumbnails

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -22,6 +22,7 @@ RESIZED_DIR  = os.path.join(SHARED_DIR, "resized")            # ≤1024 for SAM
 MASKS_DIR    = os.path.join(SHARED_DIR, "output", "masks")    # from Server2
 CROPS_DIR    = os.path.join(SHARED_DIR, "output", "crops")    # RGBA crops
 SMALLS_DIR   = os.path.join(SHARED_DIR, "output", "smalls")
+POINTS_DIR   = os.path.join(SHARED_DIR, "output", "points")
 PROCESSED_FILE = os.path.join(SHARED_DIR, "output", "processed.json")
 CONFIG_DIR   = os.path.join(SHARED_DIR, "config")
 SETTINGS_JSON = os.path.join(CONFIG_DIR, "settings.json")
@@ -30,7 +31,7 @@ CROPS_INDEX   = os.path.join(CROPS_DIR, "index.json")         # manifest linking
 MAX_RESIZE = 1024  # longest side for SAM
 ALLOWED_EXT = {"png", "jpg", "jpeg", "webp", "bmp", "tiff", "heic", "heif"}
 
-for d in [INPUT_DIR, RESIZED_DIR, MASKS_DIR, CROPS_DIR, SMALLS_DIR, CONFIG_DIR]:
+for d in [INPUT_DIR, RESIZED_DIR, MASKS_DIR, CROPS_DIR, SMALLS_DIR, CONFIG_DIR, POINTS_DIR]:
     os.makedirs(d, exist_ok=True)
 
 # Register HEIF opener for Pillow
@@ -254,10 +255,24 @@ def list_originals():
             except Exception:
                 pass
             crops.append({"file": c, "url": f"/crops/{c}", "area": area})
+
+        points_info = None
+        base_name = os.path.splitext(f)[0]
+        pts_path = os.path.join(POINTS_DIR, f"{base_name}.json")
+        if os.path.exists(pts_path):
+            try:
+                with open(pts_path, "r") as pf:
+                    pts = json.load(pf)
+                if isinstance(pts, dict) and "points" in pts:
+                    points_info = pts
+            except Exception:
+                points_info = None
+
         albums.append({
             "original": f,
             "original_url": f"/input/{f}",
-            "crops": crops
+            "crops": crops,
+            "yolo": points_info
         })
 
     return jsonify(albums)

--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -294,13 +294,37 @@
         head.className="albumHead"; head.dataset.original = a.original;
         const isOpen = !!openState[a.original]; const arrow = isOpen ? "▲" : "▼";
         head.innerHTML = `
-          <img class="thumb" src="${a.original_url}" alt="">
+          <div class="thumbWrap" style="position:relative;">
+            <img class="thumb" src="${a.original_url}" alt="">
+          </div>
           <div class="meta">
             <b>${a.original}</b>
             <span>${a.crops.length} clipping${a.crops.length===1?"":"s"}</span>
           </div>
           <div class="arrow" style="margin-left:auto;color:var(--sub);">${arrow}</div>
         `;
+
+        // overlay YOLO points as stars on thumbnail
+        if(a.yolo && a.yolo.points && a.yolo.points.length){
+          const tw=head.querySelector('.thumbWrap');
+          const w=a.yolo.width, h=a.yolo.height; const box=96;
+          let sw,sh,offX,offY;
+          if(w>=h){
+            sw=box; sh=h*(box/w); offX=0; offY=(box-sh)/2;
+          }else{
+            sh=box; sw=w*(box/h); offX=(box-sw)/2; offY=0;
+          }
+          a.yolo.points.forEach(pt=>{
+            const star=document.createElement('div');
+            star.textContent='★';
+            star.style.position='absolute';
+            star.style.color='yellow';
+            star.style.fontSize='12px';
+            const x=offX + (pt[0]/w)*sw; const y=offY + (pt[1]/h)*sh;
+            star.style.left=`${x-6}px`; star.style.top=`${y-6}px`;
+            tw.appendChild(star);
+          });
+        }
 
         const body = document.createElement("div");
         body.className="albumBody"; body.style.display = isOpen ? "block" : "none";


### PR DESCRIPTION
## Summary
- persist YOLO midpoint detections for each processed image
- expose YOLO points in `list_originals` API and draw stars on corresponding thumbnail locations

## Testing
- `python -m py_compile server1/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b197ea1d50832eb486874451b01edd