### PR TITLE
Log YOLO availability when skipping point generation

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -142,7 +142,13 @@ def _get_yolo_points(image_path: str) -> list[tuple[float, float, int]]:
     """
 
     points: list[tuple[float, float, int]] = []
-    if not _YOLO_AVAILABLE or not os.path.isdir(YOLO_MODELS_DIR):
+    if not _YOLO_AVAILABLE:
+        print("[Worker] YOLO models not available, skipping YOLO point generation")
+        return points
+    if not os.path.isdir(YOLO_MODELS_DIR):
+        print(
+            f"[Worker] YOLO models directory '{YOLO_MODELS_DIR}' not found, skipping"
+        )
         return points
 
     base_name = os.path.splitext(os.path.basename(image_path))[0]


### PR DESCRIPTION
## Summary
- Log a clear message when YOLO models are unavailable
- Log when YOLO model directory is missing to explain skipped detections

## Testing
- `python -m py_compile server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b217d68e18832e976f29ce135c10c0