### PR TITLE
Add thumbnail support for faster gallery loading

### DIFF
--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -295,7 +295,7 @@
         const isOpen = !!openState[a.original]; const arrow = isOpen ? "▲" : "▼";
         head.innerHTML = `
           <div class="thumbWrap" style="position:relative;">
-            <img class="thumb" src="${a.original_url}" alt="">
+            <img class="thumb" src="${a.thumb_url}" alt="">
           </div>
           <div class="meta">
             <b>${a.original}</b>
@@ -339,7 +339,7 @@
         }else{
           a.crops.forEach(c=>{
             const chip=document.createElement("div"); chip.className="chip";
-            const img=document.createElement("img"); img.src=c.url; img.alt=c.file; img.title="Add to canvas";
+            const img=document.createElement("img"); img.src=c.thumb_url; img.alt=c.file; img.title="Add to canvas";
             img.onclick=()=> addToCanvas(c.url);
             chip.appendChild(img); chips.appendChild(chip);
           });


### PR DESCRIPTION
## Summary
- Generate small thumbnails when uploading originals and creating crops
- Serve thumbnails via new `/thumbs` route and include their URLs in listing APIs
- Update front-end to display thumbnails but load full-resolution images onto canvas

## Testing
- `python -m py_compile server1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b21b779dac832e88d796ceeb2e0b1a