### PR TITLE
Skip non-YOLO models when detecting points

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -159,6 +159,10 @@ def _get_yolo_points(image_path: str) -> list[tuple[float, float, int]]:
     for fname in os.listdir(YOLO_MODELS_DIR):
         if not fname.lower().endswith((".pt", ".onnx")):
             continue
+        # Skip any non-YOLO models such as the BirefNet weights which share
+        # the models directory but are incompatible with the YOLO API.
+        if "birefnet" in fname.lower():
+            continue
         model_path = os.path.join(YOLO_MODELS_DIR, fname)
         print(f"[Worker] Running YOLO model {fname}")
         try:


### PR DESCRIPTION
## Summary
- avoid loading non-YOLO model files (e.g. BirefNet weights) when running YOLO inference

## Testing
- `python -m py_compile server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b240551268832eaf556ac4b3b13a2e