### PR TITLE
Refine mask merging logic to combine only overlapping masks

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -341,28 +341,50 @@ def generate_masks(image_path, settings, points=None):
 
     return masks, image
 
-def merge_touching_masks(masks: list[dict], image_shape: tuple[int, int]) -> list[dict]:
-    """Merge masks that overlap or touch into single masks.
+def merge_overlapping_masks(masks: list[dict], image_shape: tuple[int, int]) -> list[dict]:
+    """Merge masks that overlap into single masks.
 
-    All input mask segmentations are resized to ``image_shape`` and combined.
-    Connected components in the union are returned as individual masks.
+    Masks that only touch are kept separate. All mask segmentations are resized
+    to ``image_shape`` before merging.
     """
     h, w = image_shape
     if not masks:
         return []
 
-    merged = np.zeros((h, w), dtype=np.uint8)
+    resized: list[np.ndarray] = []
     for m in masks:
         seg = m["segmentation"].astype(np.uint8)
         if seg.shape != (h, w):
             seg = cv2.resize(seg, (w, h), interpolation=cv2.INTER_NEAREST)
-        merged |= seg
+        resized.append(seg.astype(bool))
 
-    num_labels, labels = cv2.connectedComponents(merged)
-    combined: list[dict] = []
-    for lbl in range(1, num_labels):
-        combined.append({"segmentation": labels == lbl})
-    return combined
+    parent = list(range(len(resized)))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for i in range(len(resized)):
+        for j in range(i + 1, len(resized)):
+            if np.any(resized[i] & resized[j]):
+                union(i, j)
+
+    groups: dict[int, np.ndarray] = {}
+    for idx, seg in enumerate(resized):
+        root = find(idx)
+        if root in groups:
+            groups[root] |= seg
+        else:
+            groups[root] = seg.copy()
+
+    return [{"segmentation": mask} for mask in groups.values()]
 
 def save_masks(masks, image, base_name):
     """Save each mask individually without merging.
@@ -434,7 +456,7 @@ while True:
 
 
                 if masks and img is not None:
-                    masks = merge_touching_masks(masks, img.shape[:2])
+                    masks = merge_overlapping_masks(masks, img.shape[:2])
                     largest = max(masks, key=lambda m: int(np.count_nonzero(m["segmentation"])))
                     if _is_mostly_one_color(img, largest["segmentation"]):
                         try:


### PR DESCRIPTION
## Summary
- Rework mask merging to combine only masks with overlapping pixels
- Skip merging for masks that merely touch and adjust worker processing accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b24a742a48832e82036058f6c16b76