### PR TITLE
RunPod serverless worker with GPU lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,60 @@
+## Building
+
+```
 docker build -t sam-server1 -f Server1.Dockerfile .
-
-docker run -it --rm -p 5050:5050 -v $(pwd)/shared:/mnt/shared -e RUNPOD_API_KEY="your_api_key_here" -e GPU_POD_ID="your_gpu_pod_id_here" sam-server1
-
 docker build -t sam-server2 -f Server2.Dockerfile .
+```
 
-docker run -it --rm -v $(pwd)/shared:/mnt/shared sam-server2
+## Running
+
+Server1 is intended to run on an AWS EC2 instance. It exposes a small web UI on
+port `5050` and expects two sets of credentials supplied via environment
+variables:
+
+* `APP_USER1` / `APP_PASS1`
+* `APP_USER2` / `APP_PASS2`
+
+The web interface presents a login form and only proceeds once a valid
+username/password pair is supplied.
+
+Both servers read and write job data and model weights from a shared storage
+location on EC2. Mount this storage into each container (or expose it via a
+network filesystem like EFS or an S3 bucket mounted with `s3fs`) and ensure both
+processes point to the same path. The base directory defaults to `/mnt/shared`
+but can be overridden with the `SHARED_DIR` environment variable.
+
+The GPU worker (Server2) is managed through the RunPod API. When a user logs in,
+Server1 submits jobs to a RunPod **serverless** endpoint. Each invocation
+processes any pending images and exits. Models are loaded once at container
+startup so warm runs reuse the weights already in memory, minimizing "cold start"
+delays.
+
+Server1 monitors the queue and stops the GPU pod five minutes after no images remain, restarting it when new files appear.
+
+```
+docker run -it --rm -p 5050:5050 \
+  -v /path/on/ec2/shared:/mnt/shared \
+  -e RUNPOD_API_KEY="your_api_key_here" \
+  -e GPU_POD_ID="your_gpu_pod_id_here" \
+  -e APP_USER1="user_a" -e APP_PASS1="pass_a" \
+  -e APP_USER2="user_b" -e APP_PASS2="pass_b" \
+  sam-server1
+```
+
+Server2 is deployed as a RunPod serverless worker. The container is still built
+from `Server2.Dockerfile`, but instead of running continuously it reacts to jobs
+from Server1 via the RunPod library. Heavy models (`segment-anything`,
+`ultralytics`, `rembg[gpu]`) are imported at module load time so they remain in
+memory between invocations when the worker is warm.
+
+### Models
+
+When Server1 starts it ensures required model weights are present under
+`shared/models`, downloading any missing files without overwriting existing
+ones. The following weights are fetched:
+
+* `vit_l.pth` – Segment Anything
+* `birefnet-dis.onnx` – rembg
+* `yolov8n.pt` and `yolov8n-seg.pt` – Ultralytics YOLO
+
+You may pre-populate `shared/models` to skip the network downloads entirely.

--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -1,4 +1,4 @@
-FROM intel/intel-optimized-pytorch
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
 
 WORKDIR /app
 

--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -80,6 +80,7 @@
 <body>
     <header>
       <div class="wrap bar">
+        <a href="/logout" class="btn ghost">Logout</a>
         <!-- Upload Queue -->
         <details class="card" id="uploadSection">
           <summary>Upload</summary>

--- a/server1/templates/login.html
+++ b/server1/templates/login.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; background:#0b0c10; color:#e9eef7; display:flex; justify-content:center; align-items:center; height:100vh; }
+    form { background:#12141a; padding:20px; border-radius:8px; display:flex; flex-direction:column; gap:10px; }
+    input { padding:8px; border-radius:4px; border:1px solid #1a1d25; background:#151926; color:#e9eef7; }
+    button { padding:8px; border-radius:4px; border:1px solid #1a1d25; background:#1e2230; color:#e9eef7; cursor:pointer; }
+    .error { color:#ff6a6a; }
+  </style>
+</head>
+<body>
+  <form method="post">
+    <h2>Login</h2>
+    {% if error %}<div class="error">{{ error }}</div>{% endif %}
+    <input type="text" name="username" placeholder="Username" required />
+    <input type="password" name="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>

--- a/server2/requirements.txt
+++ b/server2/requirements.txt
@@ -3,9 +3,10 @@ numpy
 torch
 torchvision
 git+https://github.com/facebookresearch/segment-anything.git
-rembg
-onnxruntime
+rembg[gpu]
 ultralytics
+# RunPod serverless runtime
+runpod
 #birefnet
 
 #segment-anything  # if pip-installable, else clone from github in Dockerfile


### PR DESCRIPTION
## Summary
- add shared `SHARED_DIR` storage and download vit_l, BiRefNet, and YOLO weights once on Server1
- require login for two env-configured users and manage RunPod GPU pod lifecycle based on queue activity
- convert Server2 into a RunPod serverless worker that preloads GPU models from shared storage and includes robust error handling

## Testing
- `python -m py_compile server1/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3097f39d4832ea5ff9e69246a0e6f